### PR TITLE
Update dead/missing modules in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git://github.com/gtalarico/airtable-python-wrapper.git#egg=airtable-python-wrapper
+pyairtable
 requests
 fs
 fs-s3fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fs-s3fs
 better_exceptions
 ruamel.yaml
 recommonmark
+airtable


### PR DESCRIPTION
https://github.com/gtalarico/airtable-python-wrapper now redirects to https://github.com/gtalarico/pyairtable, so `git://github.com/gtalarico/airtable-python-wrapper.git#egg=airtable-python-wrapper` prints a vague error about failing to connect to github servers which sent me on a wild goose chase, messing with my firewall to see if anything was blocking the script when it was just pointing to a dead URL
Also added the airtable module which was required by the above